### PR TITLE
Fix server error handler and duplicate route

### DIFF
--- a/02_Server/app.js
+++ b/02_Server/app.js
@@ -28,7 +28,7 @@ mongoose
   .connect(process.env.MONGODB_URL, { useNewUrlParser: true })
   .then(() => {
     // Listen for requests
-    app.listen(process.env.port || 4000, function() {
+      app.listen(process.env.PORT || 4000, function() {
       console.log('Connected to Mongodb');
       console.log('API listening on port 4000');
       console.log('Server started and wait requests');

--- a/02_Server/package.json
+++ b/02_Server/package.json
@@ -4,7 +4,7 @@
     "description": "Server on Node.js for Geography quiz.",
     "main": "app.js",
     "scripts": {
-        "test": "npm test",
+        "test": "echo \"Error: no test specified\" && exit 1",
         "start": "node app.js"
     },
     "repository": {

--- a/02_Server/routes/questionRoutes.js
+++ b/02_Server/routes/questionRoutes.js
@@ -5,8 +5,8 @@ const router = Router();
 
 // TODO: Add controllers
 
-const serverError = () => {
-  console.log('Server not work!');
+const serverError = res => err => {
+  console.error('Server not work!', err);
   res.status(500).send('Server not work!');
 };
 
@@ -17,23 +17,16 @@ const serverError = () => {
 router.get('/', (req, res) => {
   Question.find()
     .then(questions => {
-      console.log('Show all questions.');
+      const amount = parseInt(req.query.amount, 10);
+      if (amount) {
+        console.log('Show ' + amount + ' questions.');
+        questions = questions.slice(0, amount);
+      } else {
+        console.log('Show all questions.');
+      }
       res.json(questions);
     })
-    .catch(serverError);
-});
-
-
-// get a specific amount of questions from the db
-router.get('/', (req, res) => {
-  Question.find()
-    .then(questions => {
-      let questionAmount = req.query.amount;
-      console.log('Show ' + questionAmount + ' questions.');
-      let result = questions.slice(0, questionAmount);
-      res.json(result);
-    })
-    .catch(serverError);
+    .catch(serverError(res));
 });
 
 // get a single question from the db
@@ -43,16 +36,16 @@ router.get('/:id', (req, res) => {
       console.log('Show one question');
       res.json(question);
     })
-    .catch(serverError);
+    .catch(serverError(res));
 });
 
 router.post('/', (req, res) => {
-  console.log('Creae new question ' + req.body);
+  console.log('Creae new question ' + JSON.stringify(req.body));
   Question.create(req.body)
     .then(question => {
       res.json(question);
     })
-    .catch(serverError);
+    .catch(serverError(res));
 });
 
 router.put('/:id', (req, res) => {
@@ -63,7 +56,7 @@ router.put('/:id', (req, res) => {
         res.json(question);
       });
     })
-    .catch(serverError);
+    .catch(serverError(res));
 });
 
 router.delete('/:id', (req, res) => {
@@ -72,7 +65,7 @@ router.delete('/:id', (req, res) => {
       console.log('Delete ' + question.toString());
       res.json(question);
     })
-    .catch(serverError);
+    .catch(serverError(res));
 });
 
 module.exports = router;


### PR DESCRIPTION
## Summary
- normalize port env variable name
- fix invalid `serverError` handler
- merge duplicate question routes
- avoid infinite `npm test` recursion

## Testing
- `npm test` (fails: no test specified)
- `npm test` in client (fails to find `react-scripts`)

------
https://chatgpt.com/codex/tasks/task_e_683f52a38c48832a93e3570e260a9ed8