### PR TITLE
Fix country name typos in quiz data

### DIFF
--- a/01_DB/data.js
+++ b/01_DB/data.js
@@ -65,7 +65,7 @@ var data = [
   },
   {
     question: 'What country calls itself Nippon',
-    answers: ['Japan', 'England', 'Russian', 'USA'],
+    answers: ['Japan', 'England', 'Russia', 'USA'],
     answer: 0,
     weight: 1,
   },
@@ -79,7 +79,7 @@ var data = [
     question: 'Which two countries are joined by the Bridge of No Return',
     answers: [
       'North Korea and South Korea',
-      'China and Jappan',
+      'China and Japan',
       'USA and USSR',
       'Ukraine and Russia',
     ],
@@ -102,7 +102,7 @@ var data = [
   {
     question:
       'Where, as of 2009, did the world’s heaviest annual rainfall on record fall',
-    answers: ['India', 'Germany', 'Franch', 'Kenya'],
+    answers: ['India', 'Germany', 'France', 'Kenya'],
     answer: 0,
     weight: 1,
   },

--- a/01_DB/setup-db.sh
+++ b/01_DB/setup-db.sh
@@ -43,7 +43,7 @@ db.questions.insertMany([{
     "weight": 1
 }, {
     "question": "What country calls itself Nippon",
-    "answers": ["Japan", "England", "Russian", "USA"],
+    "answers": ["Japan", "England", "Russia", "USA"],
     "answer": 0,
     "weight": 1
 }, {
@@ -53,7 +53,7 @@ db.questions.insertMany([{
     "weight": 1
 }, {
     "question": "Which two countries are joined by the Bridge of No Return",
-    "answers": ["North Korea and South Korea", "China and Jappan", "USA and USSR", "Ukraine and Russia"],
+    "answers": ["North Korea and South Korea", "China and Japan", "USA and USSR", "Ukraine and Russia"],
     "answer": 0,
     "weight": 1
 }, {
@@ -68,7 +68,7 @@ db.questions.insertMany([{
     "weight": 1
 }, {
     "question": "Where, as of 2009, did the world’s heaviest annual rainfall on record fall",
-    "answers": ["India", "Germany", "Franch", "Kenya"],
+    "answers": ["India", "Germany", "France", "Kenya"],
     "answer": 0,
     "weight": 1
 }, {


### PR DESCRIPTION
## Summary
- correct "Jappan" -> "Japan" in quiz seed data and db setup script
- fix other misspelled country names

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f54725bf8832aba0dca4cd2a69ae0