### PR TITLE
Update serverError handler

### DIFF
--- a/02_Server/routes/questionRoutes.js
+++ b/02_Server/routes/questionRoutes.js
@@ -5,9 +5,17 @@ const router = Router();
 
 // TODO: Add controllers
 
-const serverError = res => err => {
-  console.error('Server not work!', err);
-  res.status(500).send('Server not work!');
+// Universal server error handler. Can be used either as middleware
+// `(err, req, res)` or as a helper returning a handler when passed only `res`.
+const serverError = (errOrRes, req, res) => {
+  if (arguments.length === 1) {
+    const response = errOrRes;
+    return error => serverError(error, null, response);
+  }
+
+  const error = errOrRes;
+  console.error('Server not working!', error);
+  res.status(500).send('Server not working!');
 };
 
 /*


### PR DESCRIPTION
## Summary
- make question route's `serverError` helper work with `(res)` or `(err, req, res)`
- keep route handlers using `serverError(res)`

## Testing
- `npm test` in `02_Server`
- `npm test --silent` in `03_Client` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f5c349bc4832a860e5469c905e165