### PR TITLE
Fix typo in question route log

### DIFF
--- a/02_Server/routes/questionRoutes.js
+++ b/02_Server/routes/questionRoutes.js
@@ -48,7 +48,7 @@ router.get('/:id', (req, res) => {
 });
 
 router.post('/', (req, res) => {
-  console.log('Creae new question ' + JSON.stringify(req.body));
+  console.log('Create new question ' + JSON.stringify(req.body));
   Question.create(req.body)
     .then(question => {
       res.json(question);


### PR DESCRIPTION
## Summary
- correct a misspelled log message in `questionRoutes.js`

## Testing
- `npm test --prefix 02_Server` *(fails: no test specified)*
- `npm test --prefix 03_Client --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f5f20835c832a871f77d474d0ad11