### PR TITLE
Use Mongo 7 base image

### DIFF
--- a/01_DB/Dockerfile
+++ b/01_DB/Dockerfile
@@ -1,4 +1,4 @@
-FROM mongo:latest
+FROM mongo:7
 
 LABEL maintainer = "xadmax@gmail.com"
 

--- a/01_DB/Dockerfile.single
+++ b/01_DB/Dockerfile.single
@@ -1,4 +1,4 @@
-FROM mongo:latest
+FROM mongo:7
 
 LABEL maintainer = "xadmax@gmail.com"
 


### PR DESCRIPTION
## Summary
- pin Mongo image version to 7 in database Dockerfiles

## Testing
- `npm install` in `03_Client`
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_683f624c09b0832aa50a36594c91ba85