### PR TITLE
Update React and Material UI

### DIFF
--- a/03_Client/package.json
+++ b/03_Client/package.json
@@ -3,11 +3,14 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "@material-ui/core": "^3.9.1",
-    "axios": "^0.18.0",
-    "react": "^16.7.0",
-    "react-dom": "^16.7.0",
-    "react-scripts": "2.1.3"
+    "@mui/material": "^5.15.8",
+    "@mui/styles": "^5.15.8",
+    "@emotion/react": "^11",
+    "@emotion/styled": "^11",
+    "axios": "^1",
+    "react": "^18",
+    "react-dom": "^18",
+    "react-scripts": "^5"
   },
   "scripts": {
     "start": "react-scripts start",
@@ -25,6 +28,6 @@
     "not op_mini all"
   ],
   "devDependencies": {
-    "prop-types": "^15.6.2"
+    "prop-types": "^15.8"
   }
 }

--- a/03_Client/src/components/Answers.js
+++ b/03_Client/src/components/Answers.js
@@ -1,20 +1,20 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { withStyles } from '@material-ui/core/styles';
-import Radio from '@material-ui/core/Radio';
-import RadioGroup from '@material-ui/core/RadioGroup';
-import FormControlLabel from '@material-ui/core/FormControlLabel';
-import FormControl from '@material-ui/core/FormControl';
+import { withStyles } from '@mui/styles';
+import Radio from '@mui/material/Radio';
+import RadioGroup from '@mui/material/RadioGroup';
+import FormControlLabel from '@mui/material/FormControlLabel';
+import FormControl from '@mui/material/FormControl';
 
 const styles = theme => ({
   root: {
     display: 'flex',
   },
   formControl: {
-    margin: theme.spacing.unit * 2,
+    margin: theme.spacing(2),
   },
   group: {
-    margin: `${theme.spacing.unit}px 0`,
+    margin: `${theme.spacing(1)} 0`,
   },
 });
 

--- a/03_Client/src/components/Modal.js
+++ b/03_Client/src/components/Modal.js
@@ -1,15 +1,15 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { withStyles } from '@material-ui/core/styles';
-import Button from '@material-ui/core/Button';
-import Dialog from '@material-ui/core/Dialog';
-import DialogActions from '@material-ui/core/DialogActions';
-import DialogContent from '@material-ui/core/DialogContent';
-import DialogTitle from '@material-ui/core/DialogTitle';
-import Slide from '@material-ui/core/Slide';
-import List from '@material-ui/core/List';
-import ListItem from '@material-ui/core/ListItem';
-import ListItemText from '@material-ui/core/ListItemText';
+import { withStyles } from '@mui/styles';
+import Button from '@mui/material/Button';
+import Dialog from '@mui/material/Dialog';
+import DialogActions from '@mui/material/DialogActions';
+import DialogContent from '@mui/material/DialogContent';
+import DialogTitle from '@mui/material/DialogTitle';
+import Slide from '@mui/material/Slide';
+import List from '@mui/material/List';
+import ListItem from '@mui/material/ListItem';
+import ListItemText from '@mui/material/ListItemText';
 
 const styles = theme => ({
   container: {

--- a/03_Client/src/components/ProgressBar.js
+++ b/03_Client/src/components/ProgressBar.js
@@ -1,6 +1,6 @@
 import React from 'react';
-import LinearProgress from '@material-ui/core/LinearProgress';
-import { withStyles } from '@material-ui/core/styles';
+import LinearProgress from '@mui/material/LinearProgress';
+import { withStyles } from '@mui/styles';
 
 const styles = {
   root: {

--- a/03_Client/src/components/Questionnaire.js
+++ b/03_Client/src/components/Questionnaire.js
@@ -1,11 +1,11 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { withStyles } from '@material-ui/core/styles';
-import Stepper from '@material-ui/core/Stepper';
-import Step from '@material-ui/core/Step';
-import StepLabel from '@material-ui/core/StepLabel';
-import StepContent from '@material-ui/core/StepContent';
-import Button from '@material-ui/core/Button';
+import { withStyles } from '@mui/styles';
+import Stepper from '@mui/material/Stepper';
+import Step from '@mui/material/Step';
+import StepLabel from '@mui/material/StepLabel';
+import StepContent from '@mui/material/StepContent';
+import Button from '@mui/material/Button';
 
 import Modal from './Modal';
 import Answers from './Answers';
@@ -18,11 +18,11 @@ const styles = theme => ({
     marginLeft: 'auto',
   },
   button: {
-    marginTop: theme.spacing.unit,
-    marginRight: theme.spacing.unit,
+    marginTop: theme.spacing(1),
+    marginRight: theme.spacing(1),
   },
   actionsContainer: {
-    marginBottom: theme.spacing.unit * 2,
+    marginBottom: theme.spacing(2),
   },
 });
 

--- a/03_Client/src/index.js
+++ b/03_Client/src/index.js
@@ -1,6 +1,7 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
+import ReactDOM from 'react-dom/client';
 import './index.css';
 import App from './components/App';
 
-ReactDOM.render(<App />, document.getElementById('root'));
+const root = ReactDOM.createRoot(document.getElementById('root'));
+root.render(<App />);


### PR DESCRIPTION
## Summary
- bump React and react-scripts
- switch from material-ui to MUI
- update source to use `createRoot` and new MUI imports

## Testing
- `npm install`
- `npm start`

------
https://chatgpt.com/codex/tasks/task_e_683f625ac288832abf2fb65eb486b5e6