### PR TITLE
Fix cleanup script sequence

### DIFF
--- a/cleanup.sh
+++ b/cleanup.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 set -e
-docker stop $(docker ps -qa) \
-    || docker rm -f $(docker ps -qa) \
-    || docker rmi -f $(docker images -qa) \
-    || docker network prune
+docker stop $(docker ps -qa)
+docker rm -f $(docker ps -qa)
+docker rmi -f $(docker images -qa)
+docker network prune


### PR DESCRIPTION
## Summary
- run all clean-up commands sequentially without OR conditions

## Testing
- `npm test` *(fails: react-scripts not found)*
- `bash cleanup.sh` *(fails: docker not found)*

------
https://chatgpt.com/codex/tasks/task_e_684064ce4fbc832a87c97416d9dbfa87