### PR TITLE
Use consistent query parameter name

### DIFF
--- a/02_Server/routes/questionRoutes.js
+++ b/02_Server/routes/questionRoutes.js
@@ -25,10 +25,10 @@ const serverError = (errOrRes, req, res) => {
 router.get('/', (req, res) => {
   Question.find()
     .then(questions => {
-      const amount = parseInt(req.query.amount, 10);
-      if (amount) {
-        console.log('Show ' + amount + ' questions.');
-        questions = questions.slice(0, amount);
+      const number = parseInt(req.query.number, 10);
+      if (number) {
+        console.log('Show ' + number + ' questions.');
+        questions = questions.slice(0, number);
       } else {
         console.log('Show all questions.');
       }

--- a/03_Client/src/utils/api.js
+++ b/03_Client/src/utils/api.js
@@ -3,8 +3,8 @@ import axios from 'axios';
 const mapper = questions =>
     questions.map(({ _id: id, ...props }) => ({ id, ...props }));
 
-export const fetchQuesions = amount =>
+export const fetchQuesions = number =>
     axios
-    .get(`http://${process.env.GEO_SRV}/questions?number=${amount}`)
+    .get(`http://${process.env.GEO_SRV}/questions?number=${number}`)
     .then(({ data }) => mapper(data))
     .catch(console.log);

--- a/create-docker-network.sh
+++ b/create-docker-network.sh
@@ -22,4 +22,4 @@ docker run -d -it -p 3000:3000 --name=geography-frontend --network geo-net geo-f
 
 sleep 5s
 
-curl -X GET http://localhost:4000/questions?amount=2
+curl -X GET http://localhost:4000/questions?number=2


### PR DESCRIPTION
## Summary
- standardize on `number` query param for fetching questions
- adjust server route for new param
- keep shell script consistent with new parameter

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684064c2b35c832ab8931f0f3115552c