### PR TITLE
Add React unit tests

### DIFF
--- a/03_Client/package.json
+++ b/03_Client/package.json
@@ -28,6 +28,9 @@
     "not op_mini all"
   ],
   "devDependencies": {
-    "prop-types": "^15.8"
+    "prop-types": "^15.8",
+    "@testing-library/react": "^14",
+    "@testing-library/jest-dom": "^6",
+    "@testing-library/user-event": "^14"
   }
 }

--- a/03_Client/src/components/App.test.js
+++ b/03_Client/src/components/App.test.js
@@ -1,0 +1,23 @@
+import { render, screen } from '@testing-library/react';
+import { ThemeProvider, createTheme } from '@mui/material/styles';
+import App from './App';
+import * as API from '../utils/api';
+
+jest.mock('../utils/api', () => ({
+  fetchQuesions: jest.fn(),
+}));
+
+const questions = [
+  { id: '1', question: 'Q1?', answers: ['A1', 'A2'], answer: 0 },
+];
+
+test('renders progress bar and then questionnaire after data load', async () => {
+  API.fetchQuesions.mockResolvedValueOnce(questions);
+  render(
+    <ThemeProvider theme={createTheme()}>
+      <App />
+    </ThemeProvider>
+  );
+  expect(screen.getByRole('progressbar')).toBeInTheDocument();
+  expect(await screen.findByText('Q1?')).toBeInTheDocument();
+});

--- a/03_Client/src/components/Modal.test.js
+++ b/03_Client/src/components/Modal.test.js
@@ -1,0 +1,23 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ThemeProvider, createTheme } from '@mui/material/styles';
+import Modal from './Modal';
+
+const score = { total: 2, correct: 2, passed: true };
+
+test('renders score information and handles retry', async () => {
+  const user = userEvent.setup();
+  const onRetry = jest.fn();
+  render(
+    <ThemeProvider theme={createTheme()}>
+      <Modal isOpen={true} onRetry={onRetry} score={score} />
+    </ThemeProvider>
+  );
+
+  expect(screen.getByText('Congratulations, you passed! 🤓')).toBeInTheDocument();
+  expect(screen.getByText('Total questions: 2')).toBeInTheDocument();
+  expect(screen.getByText('Answered correctly: 2')).toBeInTheDocument();
+
+  await user.click(screen.getByRole('button', { name: /retry/i }));
+  expect(onRetry).toHaveBeenCalled();
+});

--- a/03_Client/src/components/Questionnaire.test.js
+++ b/03_Client/src/components/Questionnaire.test.js
@@ -1,0 +1,28 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ThemeProvider, createTheme } from '@mui/material/styles';
+import Questionnaire from './Questionnaire';
+
+const questions = [
+  { id: '1', question: 'Q1?', answers: ['A1', 'A2'], answer: 0 },
+  { id: '2', question: 'Q2?', answers: ['B1', 'B2'], answer: 1 },
+];
+
+test('navigates through questions and shows score modal', async () => {
+  const user = userEvent.setup();
+  render(
+    <ThemeProvider theme={createTheme()}>
+      <Questionnaire questions={questions} />
+    </ThemeProvider>
+  );
+
+  expect(screen.getByText('Q1?')).toBeInTheDocument();
+  await user.click(screen.getByLabelText('A1'));
+  await user.click(screen.getByRole('button', { name: /next/i }));
+
+  expect(screen.getByText('Q2?')).toBeInTheDocument();
+  await user.click(screen.getByLabelText('B2'));
+  await user.click(screen.getByRole('button', { name: /finish/i }));
+
+  expect(await screen.findByText(/congratulations/i)).toBeInTheDocument();
+});

--- a/03_Client/src/setupTests.js
+++ b/03_Client/src/setupTests.js
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';


### PR DESCRIPTION
## Summary
- add testing-library dependencies
- create setupTests with jest-dom
- test App component fetching and rendering flow
- test Questionnaire flow through questions
- test Modal score output and retry handler

## Testing
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_684064d55750832a89a7576edb7f8414